### PR TITLE
Hide some job table columns by default.

### DIFF
--- a/src/ensembl/production/datacheck/templates/list.html
+++ b/src/ensembl/production/datacheck/templates/list.html
@@ -12,7 +12,6 @@
 <div class="col-12">
 <table id="table"
   class="table table-striped thead-dark table-bordered "
-  id="table"
   data-toggle="table"
   data-row-style="rowStyle"
   data-search="true"
@@ -28,16 +27,16 @@
   data-detail-view-icon="true"
   data-detail-formatter="detailFormatter"
   data-buttons-class="btn h-buttons"
-  data-query-params="queryParams"
-  data-show-columns="true">
+  data-query-params="queryParams">
   <thead>
     <tr style="cursor: pointer">
       <!--<th data-formatter="expandIcon"></th>-->
       <th data-field="id" data-sortable="true" data-formatter="detailPage">ID</th>
       <!--<th data-field="input.db_type" data-sortable="true">DB Type</th>-->
-      <th data-field="input.dbname" data-sortable="true" data-formatter="FormatArrayName"  >DB Name</th>
-      <th data-field="input.datacheck_types" data-sortable="true" data-formatter="FormatArrayName"  >Datacheck types</th>
-      <th data-field="input.datacheck_groups" data-sortable="true" data-formatter="FormatArrayName"  >Datacheck groups</th>
+      <th data-field="input.dbname" data-sortable="true" data-formatter="FormatArrayName"  >Database</th>
+      <th data-field="input.datacheck_names" data-sortable="true" data-formatter="FormatArrayName" data-visible="false" >Datacheck Names</th>
+      <th data-field="input.datacheck_types" data-sortable="true" data-formatter="FormatArrayName" data-visible="false" >Datacheck Types</th>
+      <th data-field="input.datacheck_groups" data-sortable="true" data-formatter="FormatArrayName" data-visible="false" >Datacheck Groups</th>
       <th data-field="status" data-sortable="true" data-formatter="statusFormat">Status</th>
       <th data-field="input.tag" data-sortable="true" >Tag</th>
       <th data-field="input.timestamp" data-sortable="true" >Start Time</th>


### PR DESCRIPTION
The datacheck table has quite a lot of columns, generally necessitating horizontal scrolling, which is a pain. Add in the datacheck name field, but make it hidden by default, along with the group and type - columns can be added by user, and this info is visible by clicking on the '+' button.
Also deleted a couple of duplicate tags.