### PR TITLE
convert string dc results from es to json file download

### DIFF
--- a/src/ensembl/production/datacheck/app/main.py
+++ b/src/ensembl/production/datacheck/app/main.py
@@ -399,7 +399,7 @@ def download_dc_outputs(job_id):
                     raise Exception(res['message'])
 
                 buffer = BytesIO()
-                buffer.write(json.dumps(res['result'], indent=2).encode('utf-8'))
+                buffer.write(json.dumps(json.loads(res['result']), indent=2).encode('utf-8'))
                 buffer.seek(0)
                 return send_file(
                     buffer,


### PR DESCRIPTION
Fix for ES indexing limit for the columns up to 1000, with this limitation we could store only 190 doc of date check results.
This change is needed as per changes in DC pipeline ref the PR: https://github.com/Ensembl/ensembl-datacheck/pull/561